### PR TITLE
Only show users current gym

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   def index
     @my_gym = current_user.gym
     @age = (18..100).to_a
-    # @users = User.where(gym: current_user.gym)
+    # @users = User.all
     @users = User.where(gym: @my_gym)
     @gyms = Gym.all
     @sports = Sport.all

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
     @my_gym = current_user.gym
     @age = (18..100).to_a
     # @users = User.where(gym: current_user.gym)
-    @users = User.all
+    @users = User.where(gym: @my_gym)
     @gyms = Gym.all
     @sports = Sport.all
     @weekdays = Weekday.all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -121,7 +121,7 @@ admins.each do |admin|
   user.sports = Sport.all.sample(i)
   e = rand(1..7)
   user.weekdays = Weekday.all.sample(e)
-  user.gym = Gym.all.sample
+  # user.gym = Gym.all.sample
   user.location = user.gym.city
   user.photo.attach(io: file, filename: "#{user.first_name}.png", content_type: 'image/png')
   user.save


### PR DESCRIPTION
fixed the bug that in users index all users are shown. Now only the users which are at the gym of the signed user are being shown. 
Seed file has been adjusted, so that all admin users are always at the same gym (for testing purposes).