### PR TITLE
fixed the dropdown menu appearance of edit user's gym

### DIFF
--- a/app/views/users/_edit_form.html.erb
+++ b/app/views/users/_edit_form.html.erb
@@ -3,7 +3,7 @@
     <%= simple_form_for(user) do |f| %>
       <%= f.input :quote %>
       <%= f.association :sports, collection: sports.uniq, input_html: {multiple: true, data: {controller: 'select2', select2_options_value: {tags: true}}}%>
-      <%= f.association :gym %>
+      <%= f.association :gym, collection: gyms.uniq, input_html: {multiple: false, data: {controller: 'select2', select2_options_value: {tags: true}}} %>
       <%= f.association :weekdays, collection: weekdays.uniq, input_html: {multiple: true, data: {controller: 'select2', select2_options_value: {tags: true}}} %>
       <%= f.submit "Save changes", class: "button-primary"%>
     <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render "edit_form", user: @user, weekdays: @weekdays, sports: @sports %>
+<%= render "edit_form", user: @user, gyms: @gyms, weekdays: @weekdays, sports: @sports %>


### PR DESCRIPTION
the dropdown menu on edit user page for gym is now consistent with other dropdown menus. 
also implemented that user can only select one gym (`multiple: false`)